### PR TITLE
fix(groups): resolve crash and stale auth after joining a group

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,6 +16,7 @@ Read this when working anywhere under `backend/`.
   - `just db-up`
   - `just db-down`
   - `just db-update`
+  - `just db-seed <clerk-sub>` — seed dev DB with test data; pass your Clerk `sub` claim as the argument (e.g. `just db-seed user_xxxx`). Idempotent — safe to run multiple times. For a clean reseed: `just db-down && just db-up && just db-seed <clerk-sub>`.
 - `just` auto-loads `backend/api/.env`; plain `dotnet` commands do not.
 - `dotnet ef` must target `--project backend/api`. Running it from the solution root without that flag fails because the `DbContext` is not defined at solution level.
 

--- a/backend/api/API/Group/GroupMutations.cs
+++ b/backend/api/API/Group/GroupMutations.cs
@@ -2,6 +2,7 @@ using api.API.Errors;
 using api.Database.Models;
 using api.Repository;
 using api.Transport;
+using GreenDonut;
 using HotChocolate.Types.Relay;
 
 namespace api.API.Group;
@@ -45,7 +46,7 @@ public static class GroupMutations
     [Error(typeof(InviteExpiredException))]
     [Error(typeof(GroupNotFoundException))]
     [Error(typeof(AlreadyMemberException))]
-    public static async Task<api.Database.Models.Group> JoinGroupAsync(
+    public static async Task<Database.Models.Group> JoinGroupAsync(
         [TokenUser] TokenUser? tokenUser,
         string inviteCode,
         IInvitesByInviteCodeDataLoader invitesDataLoader,
@@ -82,13 +83,18 @@ public static class GroupMutations
         {
             throw new AlreadyMemberException();
         }
-        return await groupRepository.AddUserToGroup(tokenUser.Id, group, cancellationToken);
+
+        var joinedGroup = await groupRepository.AddUserToGroup(tokenUser.Id, group, cancellationToken);
+        groupsByUserIdsDataLoader.RemoveCacheEntry(tokenUser.Id);
+        return joinedGroup;
+
+
     }
 
 
     [Error<NoUserException>]
     [Error<GroupLimitExceededException>]
-    public static async Task<api.Database.Models.Group> CreateGroupAsync(
+    public static async Task<Database.Models.Group> CreateGroupAsync(
         [TokenUser] TokenUser? tokenUser,
         string name,
         string? description,

--- a/backend/api/API/Group/GroupMutations.cs
+++ b/backend/api/API/Group/GroupMutations.cs
@@ -2,6 +2,7 @@ using api.API.Errors;
 using api.Database.Models;
 using api.Repository;
 using api.Transport;
+using HotChocolate.Types.Relay;
 
 namespace api.API.Group;
 

--- a/backend/api/API/Group/GroupMutations.cs
+++ b/backend/api/API/Group/GroupMutations.cs
@@ -2,8 +2,6 @@ using api.API.Errors;
 using api.Database.Models;
 using api.Repository;
 using api.Transport;
-using GreenDonut;
-using HotChocolate.Types.Relay;
 
 namespace api.API.Group;
 

--- a/backend/api/Database/Seeder.cs
+++ b/backend/api/Database/Seeder.cs
@@ -17,12 +17,14 @@ public static class Seeder
         var now = DateTimeOffset.UtcNow;
 
         // ── Users ─────────────────────────────────────────────────────────
-        var me = new User { Id = myUserId, FirstName = "Dev", LastName = "User" };
+        // The dev user may already exist if they have registered via Clerk before seeding.
+        var me = await db.Users.FindAsync(myUserId)
+                 ?? db.Users.Add(new User { Id = myUserId, FirstName = "Dev", LastName = "User" }).Entity;
         var alice = new User { Id = "user_seed_alice001", FirstName = "Alice", LastName = "Andersen" };
         var bob = new User { Id = "user_seed_bob001", FirstName = "Bob", LastName = "Bergström" };
         var carol = new User { Id = "user_seed_carol001", FirstName = "Carol", LastName = "Chen" };
 
-        db.Users.AddRange(me, alice, bob, carol);
+        db.Users.AddRange(alice, bob, carol);
         await db.SaveChangesAsync();
 
         // ── Groups ────────────────────────────────────────────────────────

--- a/backend/api/Database/Seeder.cs
+++ b/backend/api/Database/Seeder.cs
@@ -1,0 +1,169 @@
+using api.Database.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Database;
+
+public static class Seeder
+{
+    public static async Task SeedAsync(TrophyDbContext db, string myUserId)
+    {
+        // Idempotency guard — if Alice is already in the DB this seed has run before.
+        if (await db.Users.AnyAsync(u => u.Id == "user_seed_alice001"))
+        {
+            Console.WriteLine("Seed data already present — skipping.");
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+
+        // ── Users ─────────────────────────────────────────────────────────
+        var me = new User { Id = myUserId, FirstName = "Dev", LastName = "User" };
+        var alice = new User { Id = "user_seed_alice001", FirstName = "Alice", LastName = "Andersen" };
+        var bob = new User { Id = "user_seed_bob001", FirstName = "Bob", LastName = "Bergström" };
+        var carol = new User { Id = "user_seed_carol001", FirstName = "Carol", LastName = "Chen" };
+
+        db.Users.AddRange(me, alice, bob, carol);
+        await db.SaveChangesAsync();
+
+        // ── Groups ────────────────────────────────────────────────────────
+        var friday = new Group
+        {
+            Name = "Friday Game Night",
+            Description = "Weekly games with friends. All skill levels welcome.",
+            AdminId = myUserId,
+            DecisionModel = Group.RuleType.Open,
+            CreatedDate = now.AddMonths(-3),
+        };
+        var office = new Group
+        {
+            Name = "Office Champions",
+            Description = "Internal league for the office crew.",
+            AdminId = bob.Id,
+            DecisionModel = Group.RuleType.Open,
+            CreatedDate = now.AddMonths(-1),
+        };
+
+        // "Board Game Café" — Carol is admin, you are NOT a member. Use invite code to join.
+        var cafe = new Group
+        {
+            Name = "Board Game Café",
+            Description = "Carol's casual group. Join with the invite to test the onboarding flow.",
+            AdminId = carol.Id,
+            DecisionModel = Group.RuleType.Open,
+            CreatedDate = now.AddDays(-7),
+        };
+
+        db.Groups.AddRange(friday, office, cafe);
+        await db.SaveChangesAsync();
+
+        // ── UserGroups ────────────────────────────────────────────────────
+        db.UserGroups.AddRange(
+            new UserGroup { UserId = myUserId, GroupId = friday.Id, JoinedAt = friday.CreatedDate },
+            new UserGroup { UserId = alice.Id, GroupId = friday.Id, JoinedAt = friday.CreatedDate },
+            new UserGroup { UserId = bob.Id, GroupId = friday.Id, JoinedAt = friday.CreatedDate },
+            new UserGroup { UserId = bob.Id, GroupId = office.Id, JoinedAt = office.CreatedDate },
+            new UserGroup { UserId = myUserId, GroupId = office.Id, JoinedAt = office.CreatedDate },
+            new UserGroup { UserId = carol.Id, GroupId = office.Id, JoinedAt = office.CreatedDate },
+            // café — you are intentionally NOT a member here
+            new UserGroup { UserId = carol.Id, GroupId = cafe.Id, JoinedAt = cafe.CreatedDate },
+            new UserGroup { UserId = alice.Id, GroupId = cafe.Id, JoinedAt = cafe.CreatedDate }
+        );
+
+        // ── GroupInvites ──────────────────────────────────────────────────
+        db.GroupInvites.AddRange(
+            new GroupInvite
+            {
+                GroupId = friday.Id,
+                InviteCode = "FRI-SEED",
+                ExpirationDate = now.AddDays(30),
+                NextAllowedResetDate = now.AddDays(1),
+            },
+            new GroupInvite
+            {
+                GroupId = office.Id,
+                InviteCode = "OFC-SEED",
+                ExpirationDate = now.AddDays(30),
+                NextAllowedResetDate = now.AddDays(1),
+            },
+            new GroupInvite
+            {
+                GroupId = cafe.Id,
+                InviteCode = "CAF-SEED",
+                ExpirationDate = now.AddDays(30),
+                NextAllowedResetDate = now.AddDays(1),
+            }
+        );
+
+        await db.SaveChangesAsync();
+
+        // ── Games ─────────────────────────────────────────────────────────
+        var chess = new Game { Name = "Chess", Emoji = "♟️", ParentGroupId = friday.Id, CreatedDate = now.AddMonths(-3) };
+        var scrabble = new Game { Name = "Scrabble", Emoji = "🔤", ParentGroupId = friday.Id, CreatedDate = now.AddMonths(-2) };
+        var darts = new Game { Name = "Darts", Emoji = "🎯", ParentGroupId = friday.Id, CreatedDate = now.AddMonths(-1) };
+        var pingpong = new Game { Name = "Ping Pong", Emoji = "🏓", ParentGroupId = office.Id, CreatedDate = now.AddMonths(-1) };
+        var trivia = new Game { Name = "Trivia", Emoji = "🧠", ParentGroupId = office.Id, CreatedDate = now.AddDays(-14) };
+
+        db.Games.AddRange(chess, scrabble, darts, pingpong, trivia);
+        await db.SaveChangesAsync();
+
+        // ── Trophies + Requests + Approvals ───────────────────────────────
+
+        // Alice won Chess — fully awarded
+        var aliceChessTrophy = new Trophy
+        {
+            GameId = chess.Id,
+            ReceiverId = alice.Id,
+            Description = "Unbeaten across three consecutive Friday evenings.",
+            AwardedDate = now.AddMonths(-2),
+        };
+
+        // Bob won Scrabble — fully awarded
+        var bobScrabbleTrophy = new Trophy
+        {
+            GameId = scrabble.Id,
+            ReceiverId = bob.Id,
+            Description = "Triple-word score master.",
+            AwardedDate = now.AddMonths(-1),
+        };
+
+        // I have a PENDING Darts request — mixed approvals, not yet awarded
+        var myDartsTrophy = new Trophy
+        {
+            GameId = darts.Id,
+            ReceiverId = myUserId,
+            Description = "Hit three bullseyes in a row on the first attempt.",
+            AwardedDate = null,
+        };
+
+        // I won Ping Pong in Office — fully awarded
+        var myPingPongTrophy = new Trophy
+        {
+            GameId = pingpong.Id,
+            ReceiverId = myUserId,
+            Description = "Undefeated in the first office round-robin.",
+            AwardedDate = now.AddDays(-7),
+        };
+
+        db.Trophies.AddRange(aliceChessTrophy, bobScrabbleTrophy, myDartsTrophy, myPingPongTrophy);
+        await db.SaveChangesAsync();
+
+        db.TrophyRequests.AddRange(
+            new TrophyRequest { TrophyId = aliceChessTrophy.Id },
+            new TrophyRequest { TrophyId = bobScrabbleTrophy.Id },
+            new TrophyRequest { TrophyId = myDartsTrophy.Id },
+            new TrophyRequest { TrophyId = myPingPongTrophy.Id }
+        );
+        await db.SaveChangesAsync();
+
+        // Approvals for the pending Darts request only (awarded trophies need none).
+        // TrophyRequest's [Key] is TrophyId, so RequestId == myDartsTrophy.Id directly.
+        db.TrophyRequestApprovals.AddRange(
+            new TrophyRequestApproval { UserId = alice.Id, RequestId = myDartsTrophy.Id, IsApproved = true },
+            new TrophyRequestApproval { UserId = bob.Id, RequestId = myDartsTrophy.Id, IsApproved = false }
+        );
+        await db.SaveChangesAsync();
+
+        Console.WriteLine($"Seed complete. Created 4 users, 3 groups, 5 games, 4 trophies (1 pending).");
+        Console.WriteLine($"Join 'Board Game Café' with invite code: CAF-SEED");
+    }
+}

--- a/backend/api/Program.cs
+++ b/backend/api/Program.cs
@@ -18,6 +18,7 @@ public class Program
     public static async Task Main(string[] args)
     {
         var isSchemaExport = args.Length > 0 && args[0] == "schema";
+        var isSeed = args.Length > 0 && args[0] == "seed";
 
         var builder = WebApplication.CreateBuilder(args);
 
@@ -132,8 +133,19 @@ public class Program
 
         using (var scope = app.Services.CreateScope())
         {
-            await scope.ServiceProvider.GetRequiredService<TrophyDbContext>()
-                .Database.MigrateAsync();
+            var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+            await db.Database.MigrateAsync();
+
+            if (isSeed)
+            {
+                if (args.Length < 2 || string.IsNullOrWhiteSpace(args[1]))
+                {
+                    Console.Error.WriteLine("Usage: seed <user-id>");
+                    return;
+                }
+                await Seeder.SeedAsync(db, args[1]);
+                return;
+            }
         }
 
         app.Run();

--- a/backend/api/Repository/GameRepository.cs
+++ b/backend/api/Repository/GameRepository.cs
@@ -55,6 +55,7 @@ public class GameRepository : IGameRepository
     public async Task<ILookup<int, Trophy>> GetTrophiesByGameIdsAsync(IReadOnlyList<int> gameIds, CancellationToken cancellationToken)
     {
         var trophies = await _context.Trophies
+            .Include(trophy => trophy.Game)
             .Include(trophy => trophy.Receiver)
             .Where(trophy => gameIds.Contains(trophy.GameId))
             .ToListAsync(cancellationToken);
@@ -64,6 +65,7 @@ public class GameRepository : IGameRepository
     public async Task<IReadOnlyDictionary<int, Trophy>> GetTrophiesByIdsAsync(IReadOnlyList<int> ids, CancellationToken cancellationToken)
     {
         return await _context.Trophies
+            .Include(trophy => trophy.Game)
             .Include(trophy => trophy.Receiver)
             .Where(trophy => ids.Contains(trophy.Id))
             .ToDictionaryAsync(trophy => trophy.Id, cancellationToken);

--- a/backend/api/Transport/FakeAuthHandler.cs
+++ b/backend/api/Transport/FakeAuthHandler.cs
@@ -20,9 +20,14 @@ public class FakeAuthHandler : AuthenticationHandler<FakeAuthHandlerOptions>
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        // Allow per-request user ID override via header (used in integration tests).
+        var userId = Context.Request.Headers.TryGetValue("X-Test-User-Id", out var headerValues)
+            ? headerValues.FirstOrDefault() ?? "user_devlocalfakeuser001"
+            : "user_devlocalfakeuser001";
+
         var claims = new List<Claim>
         {
-            new(ClaimTypes.NameIdentifier, "user_devlocalfakeuser001"),
+            new(ClaimTypes.NameIdentifier, userId),
             new(ClaimTypes.Name, "Developer Dude"),
             new(ClaimTypes.Email, "dev@trophydev.com"),
             new(ClaimTypes.Role, "Admin")

--- a/backend/api/Transport/FakeAuthHandler.cs
+++ b/backend/api/Transport/FakeAuthHandler.cs
@@ -21,9 +21,10 @@ public class FakeAuthHandler : AuthenticationHandler<FakeAuthHandlerOptions>
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         // Allow per-request user ID override via header (used in integration tests).
-        var userId = Context.Request.Headers.TryGetValue("X-Test-User-Id", out var headerValues)
-            ? headerValues.FirstOrDefault() ?? "user_devlocalfakeuser001"
-            : "user_devlocalfakeuser001";
+        var headerValue = Context.Request.Headers.TryGetValue("X-Test-User-Id", out var headerValues)
+            ? headerValues.FirstOrDefault()
+            : null;
+        var userId = string.IsNullOrWhiteSpace(headerValue) ? "user_devlocalfakeuser001" : headerValue;
 
         var claims = new List<Claim>
         {

--- a/backend/tests/Integration/GameIntegrationTests.cs
+++ b/backend/tests/Integration/GameIntegrationTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using api.Database;
+using HotChocolate.Types.Relay;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace tests.Integration;
+
+[TestFixture]
+public class GameIntegrationTests
+{
+    private TrophyWebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUpAsync()
+    {
+        _factory = new TrophyWebAppFactory();
+        await _factory.InitializeAsync();
+        _client = _factory.CreateClient();
+        await _factory.ApplyMigrationsAsync();
+    }
+
+    [TearDown]
+    public async Task TearDownAsync()
+    {
+        using var scope = _factory.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+        await TestDataBuilder.ClearAllDataAsync(db);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDownAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Test]
+    public async Task CreateGame_WithDuplicateEmoji_ShouldReturnDuplicateGameEmojiError()
+    {
+        // Arrange
+        const string adminId = "user_game_admin_001";
+        const string emoji = "🎮";
+
+        int groupId;
+        using (var scope = _factory.CreateDbScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+            await TestDataBuilder.CreateUserAsync(db, adminId, "Admin", "Game");
+            var group = await TestDataBuilder.CreateGroupAsync(db, adminId, "Gaming Group");
+            groupId = group.Id;
+            await TestDataBuilder.CreateGameAsync(db, group.Id, "Original Game", emoji);
+        }
+
+        string relayGroupId;
+        using (var idScope = _factory.CreateDbScope())
+        {
+            var serializer = idScope.ServiceProvider.GetRequiredService<INodeIdSerializer>();
+            relayGroupId = serializer.Format("Group", groupId);
+        }
+
+        const string mutation = """
+            mutation CreateGame($input: CreateGameInput!) {
+              createGame(input: $input) {
+                game { id }
+                errors { __typename }
+              }
+            }
+            """;
+
+        // Act
+        using var result = await GraphQLHelpers.ExecuteAsync(
+            _client, adminId, mutation,
+            new { input = new { groupId = relayGroupId, name = "Duplicate Game", symbol = emoji } });
+
+        // Assert: a DuplicateGameEmojiError is returned and no game was created
+        var createGame = result.RootElement.GetProperty("data").GetProperty("createGame");
+
+        var gameNode = createGame.GetProperty("game");
+        Assert.That(gameNode.ValueKind, Is.EqualTo(JsonValueKind.Null),
+            "Expected no game to be created when the emoji is already in use");
+
+        var errors = createGame.GetProperty("errors");
+        Assert.That(errors.ValueKind, Is.Not.EqualTo(JsonValueKind.Null));
+        Assert.That(errors.GetArrayLength(), Is.GreaterThan(0), "Expected at least one error");
+
+        var firstErrorTypeName = errors[0].GetProperty("__typename").GetString();
+        Assert.That(firstErrorTypeName, Is.EqualTo("DuplicateGameEmojiError"),
+            "Expected a DuplicateGameEmojiError when creating a game with a duplicate emoji");
+    }
+}

--- a/backend/tests/Integration/GameIntegrationTests.cs
+++ b/backend/tests/Integration/GameIntegrationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace tests.Integration;
 
 [TestFixture]
+[Category("Integration")]
 public class GameIntegrationTests
 {
     private TrophyWebAppFactory _factory = null!;

--- a/backend/tests/Integration/GraphQLHelpers.cs
+++ b/backend/tests/Integration/GraphQLHelpers.cs
@@ -1,0 +1,24 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace tests.Integration;
+
+public static class GraphQLHelpers
+{
+    public static async Task<JsonDocument> ExecuteAsync(
+        HttpClient client,
+        string userId,
+        string query,
+        object? variables = null)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql");
+        request.Headers.Add("X-Test-User-Id", userId);
+        request.Content = JsonContent.Create(new { query, variables });
+
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(content);
+    }
+}

--- a/backend/tests/Integration/GraphQLHelpers.cs
+++ b/backend/tests/Integration/GraphQLHelpers.cs
@@ -15,7 +15,7 @@ public static class GraphQLHelpers
         request.Headers.Add("X-Test-User-Id", userId);
         request.Content = JsonContent.Create(new { query, variables });
 
-        var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request);
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync();

--- a/backend/tests/Integration/GroupIntegrationTests.cs
+++ b/backend/tests/Integration/GroupIntegrationTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using api.Database;
+using api.Database.Models;
+using HotChocolate.Types.Relay;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace tests.Integration;
+
+[TestFixture]
+public class GroupIntegrationTests
+{
+    private TrophyWebAppFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUpAsync()
+    {
+        _factory = new TrophyWebAppFactory();
+        await _factory.InitializeAsync();
+        _client = _factory.CreateClient();
+        await _factory.ApplyMigrationsAsync();
+    }
+
+    [TearDown]
+    public async Task TearDownAsync()
+    {
+        using var scope = _factory.CreateDbScope();
+        var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+        await TestDataBuilder.ClearAllDataAsync(db);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDownAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    [Test]
+    public async Task JoinGroup_WithValidInviteCode_ShouldSucceedAndUserShouldBelongToGroup()
+    {
+        // Arrange
+        const string adminId = "user_group_admin_001";
+        const string joinerId = "user_group_joiner_001";
+        const string inviteCode = "TSTCD001";
+
+        int groupId;
+        using (var scope = _factory.CreateDbScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+            await TestDataBuilder.CreateUserAsync(db, adminId, "Admin", "One");
+            await TestDataBuilder.CreateUserAsync(db, joinerId, "Joiner", "One");
+            var group = await TestDataBuilder.CreateGroupAsync(db, adminId, "Joinable Group");
+            groupId = group.Id;
+            await TestDataBuilder.CreateGroupInviteAsync(db, group.Id, inviteCode);
+        }
+
+        const string mutation = """
+            mutation JoinGroup($input: JoinGroupInput!) {
+              joinGroup(input: $input) {
+                group { id }
+                errors { __typename }
+              }
+            }
+            """;
+
+        // Act
+        using var result = await GraphQLHelpers.ExecuteAsync(
+            _client, joinerId, mutation, new { input = new { inviteCode } });
+
+        // Assert: mutation returned a group with no errors
+        var joinGroup = result.RootElement.GetProperty("data").GetProperty("joinGroup");
+        var groupNode = joinGroup.GetProperty("group");
+        Assert.That(groupNode.ValueKind, Is.Not.EqualTo(JsonValueKind.Null),
+            "Expected group to be returned after joining");
+
+        var errorsNode = joinGroup.GetProperty("errors");
+        Assert.That(
+            errorsNode.ValueKind == JsonValueKind.Null || errorsNode.GetArrayLength() == 0,
+            Is.True, "Expected no errors after joining with a valid invite code");
+
+        // Assert: joiner is now stored as a group member in the database
+        using var verifyScope = _factory.CreateDbScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+        var isMember = await verifyDb.UserGroups
+            .AnyAsync(ug => ug.UserId == joinerId && ug.GroupId == groupId);
+        Assert.That(isMember, Is.True, "Expected the joiner to be recorded as a group member");
+    }
+
+    [Test]
+    public async Task GetGroupById_WhenUserIsNotMember_ShouldReturnAuthorizationError()
+    {
+        // Arrange
+        const string adminId = "user_group_admin_002";
+        const string nonMemberId = "user_group_nonmember_002";
+
+        Group group;
+        using (var scope = _factory.CreateDbScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+            await TestDataBuilder.CreateUserAsync(db, adminId, "Admin", "Two");
+            await TestDataBuilder.CreateUserAsync(db, nonMemberId, "NonMember", "Two");
+            group = await TestDataBuilder.CreateGroupAsync(db, adminId, "Members Only Group");
+        }
+
+        string relayGroupId;
+        using (var idScope = _factory.CreateDbScope())
+        {
+            var serializer = idScope.ServiceProvider.GetRequiredService<INodeIdSerializer>();
+            relayGroupId = serializer.Format("Group", group.Id);
+        }
+
+        const string query = """
+            query GetGroup($id: ID!) {
+              groupById(id: $id) {
+                id
+                name
+              }
+            }
+            """;
+
+        // Act
+        using var result = await GraphQLHelpers.ExecuteAsync(
+            _client, nonMemberId, query, new { id = relayGroupId });
+
+        // Assert: the non-member receives an authorization error and no group data
+        Assert.That(
+            result.RootElement.TryGetProperty("errors", out var errors) && errors.GetArrayLength() > 0,
+            Is.True, "Expected GraphQL errors for an unauthorized group access");
+
+        var groupData = result.RootElement.GetProperty("data").GetProperty("groupById");
+        Assert.That(groupData.ValueKind, Is.EqualTo(JsonValueKind.Null),
+            "Expected groupById to be null for a non-member");
+    }
+}

--- a/backend/tests/Integration/GroupIntegrationTests.cs
+++ b/backend/tests/Integration/GroupIntegrationTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace tests.Integration;
 
 [TestFixture]
+[Category("Integration")]
 public class GroupIntegrationTests
 {
     private TrophyWebAppFactory _factory = null!;

--- a/backend/tests/Integration/TestDataBuilder.cs
+++ b/backend/tests/Integration/TestDataBuilder.cs
@@ -1,0 +1,92 @@
+using api.Database;
+using api.Database.Models;
+
+namespace tests.Integration;
+
+public static class TestDataBuilder
+{
+    public static async Task<User> CreateUserAsync(
+        TrophyDbContext db,
+        string userId,
+        string firstName = "Test",
+        string lastName = "User")
+    {
+        var user = new User { Id = userId, FirstName = firstName, LastName = lastName };
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        return user;
+    }
+
+    /// <summary>
+    /// Creates a group and adds the admin as its first member.
+    /// </summary>
+    public static async Task<Group> CreateGroupAsync(
+        TrophyDbContext db,
+        string adminId,
+        string name = "Test Group")
+    {
+        var group = new Group
+        {
+            Name = name,
+            AdminId = adminId,
+            DecisionModel = Group.RuleType.Open,
+            CreatedDate = DateTimeOffset.UtcNow,
+        };
+        db.Groups.Add(group);
+        await db.SaveChangesAsync();
+
+        db.UserGroups.Add(new UserGroup { UserId = adminId, GroupId = group.Id, JoinedAt = DateTimeOffset.UtcNow });
+        await db.SaveChangesAsync();
+
+        return group;
+    }
+
+    public static async Task<GroupInvite> CreateGroupInviteAsync(
+        TrophyDbContext db,
+        int groupId,
+        string inviteCode,
+        DateTimeOffset? expirationDate = null)
+    {
+        var invite = new GroupInvite
+        {
+            GroupId = groupId,
+            InviteCode = inviteCode,
+            ExpirationDate = expirationDate ?? DateTimeOffset.UtcNow.AddDays(7),
+            NextAllowedResetDate = DateTimeOffset.UtcNow,
+        };
+        db.GroupInvites.Add(invite);
+        await db.SaveChangesAsync();
+        return invite;
+    }
+
+    public static async Task<Game> CreateGameAsync(
+        TrophyDbContext db,
+        int groupId,
+        string name,
+        string emoji)
+    {
+        var game = new Game
+        {
+            Name = name,
+            Emoji = emoji,
+            ParentGroupId = groupId,
+            CreatedDate = DateTimeOffset.UtcNow,
+        };
+        db.Games.Add(game);
+        await db.SaveChangesAsync();
+        return game;
+    }
+
+    public static async Task ClearAllDataAsync(TrophyDbContext db)
+    {
+        db.TrophyRequestApprovals.RemoveRange(db.TrophyRequestApprovals);
+        db.TrophyRequests.RemoveRange(db.TrophyRequests);
+        db.Trophies.RemoveRange(db.Trophies);
+        db.Games.RemoveRange(db.Games);
+        db.GroupInvites.RemoveRange(db.GroupInvites);
+        db.UserGroups.RemoveRange(db.UserGroups);
+        db.Groups.RemoveRange(db.Groups);
+        db.Users.RemoveRange(db.Users);
+        await db.SaveChangesAsync();
+    }
+}

--- a/backend/tests/Integration/TrophyWebAppFactory.cs
+++ b/backend/tests/Integration/TrophyWebAppFactory.cs
@@ -25,9 +25,9 @@ public sealed class TrophyWebAppFactory : WebApplicationFactory<Program>
         await _postgres.StartAsync();
     }
 
-    public new async Task DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        await _postgres.StopAsync();
+        await _postgres.DisposeAsync();
         await base.DisposeAsync();
     }
 

--- a/backend/tests/Integration/TrophyWebAppFactory.cs
+++ b/backend/tests/Integration/TrophyWebAppFactory.cs
@@ -1,0 +1,69 @@
+using api;
+using api.Database;
+using api.Transport;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Testcontainers.PostgreSql;
+
+namespace tests.Integration;
+
+public sealed class TrophyWebAppFactory : WebApplicationFactory<Program>
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder()
+        .WithDatabase("trophy_test")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        await _postgres.StopAsync();
+        await base.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Replace DbContext pool with a plain scoped DbContext pointing at the test container.
+            services.RemoveAll<TrophyDbContext>();
+            services.RemoveAll<DbContextOptions<TrophyDbContext>>();
+            services.AddDbContext<TrophyDbContext>(options =>
+                options.UseNpgsql(_postgres.GetConnectionString()));
+
+            // Replace JWT auth with the in-process FakeAuthHandler.
+            // PostConfigure runs after all Configure actions, guaranteeing the override wins.
+            services.PostConfigure<AuthenticationOptions>(options =>
+            {
+                options.DefaultScheme = FakeAuthHandler.AuthenticationScheme;
+                options.DefaultAuthenticateScheme = FakeAuthHandler.AuthenticationScheme;
+                options.DefaultChallengeScheme = FakeAuthHandler.AuthenticationScheme;
+                options.DefaultForbidScheme = FakeAuthHandler.AuthenticationScheme;
+            });
+            services.AddAuthentication()
+                .AddScheme<FakeAuthHandlerOptions, FakeAuthHandler>(
+                    FakeAuthHandler.AuthenticationScheme, _ => { });
+        });
+    }
+
+    public async Task ApplyMigrationsAsync()
+    {
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TrophyDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public IServiceScope CreateDbScope() => Services.CreateScope();
+}

--- a/backend/tests/tests.csproj
+++ b/backend/tests/tests.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
         <PackageReference Include="NUnit" Version="4.0.1" />
@@ -18,9 +19,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="Snapper.Nunit" Version="2.4.1" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     </ItemGroup>
 
 

--- a/justfile
+++ b/justfile
@@ -65,6 +65,10 @@ migrate name:
 db-update:
     dotnet ef database update --project backend/api
 
+# Seed the dev database with realistic test data (usage: just db-seed user_xxxx)
+db-seed user-id:
+    dotnet run --project backend/api -- seed {{user-id}}
+
 # ── Full stack ───────────────────────────────────────────
 
 # Start everything for local development


### PR DESCRIPTION
Fixes a crash that occurred when joining a group and resolves a stale auth policy issue caused by the DataLoader cache not being evicted after membership was created.

### Changes

- **fix(groups):** Evict DataLoader cache after join so the auth policy immediately sees the new membership
- **fix(repository):** Fix crash in repository layer
- **test(graphql):** Integration tests covering group join, access control enforcement, and duplicate emoji validation
- **chore(backend):** Database seeding functionality for local development

closes #30