### PR TITLE
fix(frontend): keep drawer action buttons visible when iOS keyboard opens

### DIFF
--- a/frontend/app/components/DrawerDialog.tsx
+++ b/frontend/app/components/DrawerDialog.tsx
@@ -11,6 +11,7 @@ import {
     Drawer,
     DrawerContent,
     DrawerDescription,
+    DrawerFooter,
     DrawerHeader,
     DrawerTitle,
     DrawerTrigger,
@@ -35,6 +36,7 @@ interface DrawerDialogProps {
     title: string;
     description?: string;
     children: React.ReactNode;
+    footer?: React.ReactNode;
 }
 
 export function DrawerDialog({
@@ -44,6 +46,7 @@ export function DrawerDialog({
     title,
     description,
     children,
+    footer,
 }: DrawerDialogProps) {
     const isDesktop = useIsDesktop();
 
@@ -57,6 +60,7 @@ export function DrawerDialog({
                         {description && <DialogDescription>{description}</DialogDescription>}
                     </DialogHeader>
                     {children}
+                    {footer}
                 </DialogContent>
             </Dialog>
         );
@@ -70,7 +74,8 @@ export function DrawerDialog({
                     <DrawerTitle>{title}</DrawerTitle>
                     {description && <DrawerDescription>{description}</DrawerDescription>}
                 </DrawerHeader>
-                <div className="px-4 pb-8">{children}</div>
+                <div className="flex-1 overflow-y-auto px-4 pb-2">{children}</div>
+                {footer && <DrawerFooter>{footer}</DrawerFooter>}
             </DrawerContent>
         </Drawer>
     );

--- a/frontend/app/components/DrawerDialog.tsx
+++ b/frontend/app/components/DrawerDialog.tsx
@@ -74,7 +74,9 @@ export function DrawerDialog({
                     <DrawerTitle>{title}</DrawerTitle>
                     {description && <DrawerDescription>{description}</DrawerDescription>}
                 </DrawerHeader>
-                <div className={`flex-1 overflow-y-auto px-4 ${footer ? "pb-2" : "pb-8"}`}>{children}</div>
+                <div className={`flex-1 overflow-y-auto px-4 ${footer ? "pb-2" : "pb-8"}`}>
+                    {children}
+                </div>
                 {footer && <DrawerFooter>{footer}</DrawerFooter>}
             </DrawerContent>
         </Drawer>

--- a/frontend/app/components/DrawerDialog.tsx
+++ b/frontend/app/components/DrawerDialog.tsx
@@ -74,7 +74,7 @@ export function DrawerDialog({
                     <DrawerTitle>{title}</DrawerTitle>
                     {description && <DrawerDescription>{description}</DrawerDescription>}
                 </DrawerHeader>
-                <div className="flex-1 overflow-y-auto px-4 pb-2">{children}</div>
+                <div className={`flex-1 overflow-y-auto px-4 ${footer ? "pb-2" : "pb-8"}`}>{children}</div>
                 {footer && <DrawerFooter>{footer}</DrawerFooter>}
             </DrawerContent>
         </Drawer>

--- a/frontend/app/components/FeedbackForm.tsx
+++ b/frontend/app/components/FeedbackForm.tsx
@@ -31,8 +31,28 @@ export function FeedbackForm({ open, onOpenChange }: FeedbackFormProps) {
             }}
             title="Send feedback"
             description="Share your thoughts, report a bug, or suggest a feature."
+            footer={
+                <div className="flex justify-end gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button type="submit" form="feedback-form" disabled={isSubmitting}>
+                        {isSubmitting ? "Sending…" : "Send feedback"}
+                    </Button>
+                </div>
+            }
         >
-            <fetcher.Form method="post" action="/feedback" className="space-y-4">
+            <fetcher.Form
+                id="feedback-form"
+                method="post"
+                action="/feedback"
+                className="space-y-4 pb-2"
+            >
                 <div className="space-y-2">
                     <Label htmlFor="feedback-title">Title</Label>
                     <Input
@@ -55,19 +75,6 @@ export function FeedbackForm({ open, onOpenChange }: FeedbackFormProps) {
                 {result?.ok === false && (
                     <p className="text-sm text-destructive">{result.message}</p>
                 )}
-                <div className="flex justify-end gap-2 pt-2">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isSubmitting}
-                        onClick={() => onOpenChange(false)}
-                    >
-                        Cancel
-                    </Button>
-                    <Button type="submit" disabled={isSubmitting}>
-                        {isSubmitting ? "Sending…" : "Send feedback"}
-                    </Button>
-                </div>
             </fetcher.Form>
         </DrawerDialog>
     );

--- a/frontend/app/components/NewGameForm.tsx
+++ b/frontend/app/components/NewGameForm.tsx
@@ -127,8 +127,31 @@ export function NewGameForm({
             }}
             title="Create a game"
             description="Define what a win means in this game."
+            footer={
+                <div className="flex justify-end gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => {
+                            onOpenChange(false);
+                            reset();
+                        }}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        form="new-game-form"
+                        busy={isSubmitting}
+                        disabled={isSubmitting}
+                    >
+                        Create game
+                    </Button>
+                </div>
+            }
         >
-            <form onSubmit={handleSubmit}>
+            <form id="new-game-form" onSubmit={handleSubmit}>
                 <div className="grid gap-6 md:grid-cols-[auto_1fr]">
                     {/* Large emoji picker column */}
                     <div className="flex flex-col items-center justify-start gap-2">
@@ -170,22 +193,6 @@ export function NewGameForm({
                 </div>
 
                 {formError && <p className="mt-4 text-sm text-destructive">{formError}</p>}
-                <div className="mt-6 flex justify-end gap-2">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isSubmitting}
-                        onClick={() => {
-                            onOpenChange(false);
-                            reset();
-                        }}
-                    >
-                        Cancel
-                    </Button>
-                    <Button type="submit" busy={isSubmitting} disabled={isSubmitting}>
-                        Create game
-                    </Button>
-                </div>
             </form>
         </DrawerDialog>
     );

--- a/frontend/app/components/NewGroupForm.tsx
+++ b/frontend/app/components/NewGroupForm.tsx
@@ -122,8 +122,31 @@ export function NewGroupForm({ open, onOpenChange, connections, onCreated }: New
             }}
             title="Create a group"
             description="Give your group a name and get started."
+            footer={
+                <div className="flex justify-end gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => {
+                            onOpenChange(false);
+                            reset();
+                        }}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        type="submit"
+                        form="new-group-form"
+                        busy={isSubmitting}
+                        disabled={isSubmitting}
+                    >
+                        Create group
+                    </Button>
+                </div>
+            }
         >
-            <form className="space-y-4" onSubmit={handleSubmit}>
+            <form id="new-group-form" className="space-y-4" onSubmit={handleSubmit}>
                 <div className="space-y-2">
                     <Label htmlFor="group-name">Name</Label>
                     <Input
@@ -146,22 +169,6 @@ export function NewGroupForm({ open, onOpenChange, connections, onCreated }: New
                     />
                 </div>
                 {formError && <p className="text-sm text-destructive">{formError}</p>}
-                <div className="flex justify-end gap-2 pt-2">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isSubmitting}
-                        onClick={() => {
-                            onOpenChange(false);
-                            reset();
-                        }}
-                    >
-                        Cancel
-                    </Button>
-                    <Button type="submit" busy={isSubmitting} disabled={isSubmitting}>
-                        Create group
-                    </Button>
-                </div>
             </form>
         </DrawerDialog>
     );

--- a/frontend/app/components/TrophyRequestForm.tsx
+++ b/frontend/app/components/TrophyRequestForm.tsx
@@ -121,10 +121,8 @@ export function TrophyRequestForm({
             }}
             title="Award a trophy"
             description="Choose who should receive this reward and add a note if you want."
-        >
-            {success ? (
-                <div className="space-y-4 py-2">
-                    <p className="text-supporting">Trophy request submitted successfully.</p>
+            footer={
+                success ? (
                     <div className="flex justify-end">
                         <Button
                             onClick={() => {
@@ -135,9 +133,37 @@ export function TrophyRequestForm({
                             Done
                         </Button>
                     </div>
+                ) : (
+                    <div className="flex justify-end gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            disabled={isSubmitting}
+                            onClick={() => {
+                                onOpenChange(false);
+                                reset();
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            form="trophy-request-form"
+                            busy={isSubmitting}
+                            disabled={isSubmitting}
+                        >
+                            Award trophy
+                        </Button>
+                    </div>
+                )
+            }
+        >
+            {success ? (
+                <div className="space-y-4 py-2">
+                    <p className="text-supporting">Trophy request submitted successfully.</p>
                 </div>
             ) : (
-                <form className="space-y-4" onSubmit={handleSubmit}>
+                <form id="trophy-request-form" className="space-y-4" onSubmit={handleSubmit}>
                     {!gameId && (
                         <div className="space-y-2">
                             <Label htmlFor="trophy-game">Game</Label>
@@ -198,22 +224,6 @@ export function TrophyRequestForm({
                         />
                     </div>
                     {formError && <p className="text-sm text-destructive">{formError}</p>}
-                    <div className="flex justify-end gap-2 pt-2">
-                        <Button
-                            type="button"
-                            variant="outline"
-                            disabled={isSubmitting}
-                            onClick={() => {
-                                onOpenChange(false);
-                                reset();
-                            }}
-                        >
-                            Cancel
-                        </Button>
-                        <Button type="submit" busy={isSubmitting} disabled={isSubmitting}>
-                            Award trophy
-                        </Button>
-                    </div>
                 </form>
             )}
         </DrawerDialog>


### PR DESCRIPTION
## Problem

On iOS, when the keyboard opens inside a bottom drawer (e.g. the feedback form or create game form), it pushes the drawer upward and compresses its visible height. Because the action buttons (Cancel / Submit) lived inside the same scrollable region as the form fields, they scrolled out of view with no affordance that they were still there.

## Fix

Restructured `DrawerDialog` to use a proper three-zone layout on mobile:

- **Header** — fixed, never scrolls
- **Content area** (`flex-1 overflow-y-auto`) — form fields scroll within available height
- **Footer** (`DrawerFooter`, `mt-auto`) — action buttons are pinned outside the scroll area and always visible

Added a `footer` prop to `DrawerDialog`. Buttons in `FeedbackForm` and `NewGameForm` are moved into this prop. Since the buttons are now outside their `<form>` element, they use the HTML `form="<id>"` attribute to still trigger the correct submission.

Closes #29