### PR TITLE
fix(caddy): route /server-info to backend

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -37,6 +37,11 @@ troji.me {
 		reverse_proxy backend:8080
 	}
 
+	# --- Backend REST endpoints ---
+	handle /server-info {
+		reverse_proxy backend:8080
+	}
+
 	# --- Frontend (React Router SSR) ---
 	handle {
 		reverse_proxy frontend:3000


### PR DESCRIPTION
## Summary

- `/server-info` was returning 404 in production because the Caddyfile only routed `/graphql*` to the backend — all other paths fell through to the frontend SSR catch-all
- Added a dedicated `handle /server-info` block to proxy the endpoint to the backend

## Test plan

- [x] Confirm `GET https://troji.me/server-info` returns `{"version":"..."}` after deploy