### PR TITLE
fix(frontend): tighten header and group page layout on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ frontend/.react-router/
 .idea/
 
 .playwright-mcp/
+
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+frontend/.env
+backend/.env
+backend/api/schema.graphql

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
 import { ClerkLoaded, ClerkLoading, UserButton } from "@clerk/react-router";
-import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline";
+import { Bars3Icon, ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline";
 import { NavLink } from "react-router";
 import { FeedbackForm } from "@/components/FeedbackForm";
 import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { VersionChip } from "@/components/VersionChip";
 
@@ -18,16 +24,67 @@ export function Header() {
     return (
         <header className="z-40 w-full border-b border-border bg-background">
             <div className="container relative mx-auto flex h-12 items-center justify-between gap-3 px-4 sm:h-14">
-                <VersionChip homeHref="/dashboard" />
+                <div className="flex items-center gap-2">
+                    <VersionChip homeHref="/dashboard" />
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label="Open navigation menu"
+                                className="xl:hidden"
+                            >
+                                <Bars3Icon className="size-5" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                            align="start"
+                            onCloseAutoFocus={(event) => event.preventDefault()}
+                            className="min-w-44 border-border bg-background p-1"
+                        >
+                            {navLinks.map(({ to, label }) => (
+                                <DropdownMenuItem key={to} asChild>
+                                    <NavLink
+                                        to={to}
+                                        className={({ isActive }) =>
+                                            [
+                                                "group flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 font-mono text-[12px] uppercase tracking-[0.18em] transition-colors",
+                                                isActive
+                                                    ? "text-medal-gold focus:text-medal-gold"
+                                                    : "text-muted-foreground hover:text-foreground",
+                                            ].join(" ")
+                                        }
+                                    >
+                                        {({ isActive }) => (
+                                            <>
+                                                <span
+                                                    aria-hidden
+                                                    className={
+                                                        isActive
+                                                            ? "text-medal-gold"
+                                                            : "text-muted-foreground/60 group-hover:text-foreground/60"
+                                                    }
+                                                >
+                                                    ▸
+                                                </span>
+                                                <span>{label}</span>
+                                            </>
+                                        )}
+                                    </NavLink>
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
 
-                <nav className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1 sm:gap-2">
+                <nav className="absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center gap-2 xl:flex">
                     {navLinks.map(({ to, label }) => (
                         <NavLink
                             key={to}
                             to={to}
                             className={({ isActive }) =>
                                 [
-                                    "group inline-flex items-center gap-1.5 rounded-sm px-2 py-1.5 font-mono text-[12px] uppercase tracking-[0.18em] transition-colors sm:px-3 sm:text-[13px]",
+                                    "group inline-flex items-center gap-1.5 rounded-sm px-3 py-1.5 font-mono text-[13px] uppercase tracking-[0.18em] transition-colors",
                                     isActive
                                         ? "text-medal-gold"
                                         : "text-muted-foreground hover:text-foreground",

--- a/frontend/app/components/ui/button.tsx
+++ b/frontend/app/components/ui/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
                 sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
                 lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
                 terminal:
-                    "h-auto gap-3 px-6 py-3 font-mono text-sm uppercase tracking-[0.18em]",
+                    "h-auto gap-2 px-4 py-2 font-mono text-xs uppercase tracking-[0.18em] sm:gap-3 sm:px-6 sm:py-3 sm:text-sm",
                 icon: "size-8",
                 "icon-xs":
                     "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",

--- a/frontend/app/routes/groups.tsx
+++ b/frontend/app/routes/groups.tsx
@@ -66,7 +66,7 @@ export default function Groups({ loaderData }: Route.ComponentProps) {
                         <span className="text-medal-gold">$</span>
                         <span className="ml-2">groups</span>
                     </p>
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                    <div className="flex flex-wrap items-end justify-between gap-4">
                         <h1 className="font-heading text-4xl italic font-medium tracking-[0.015em] text-foreground sm:text-5xl">
                             Your circles.
                         </h1>


### PR DESCRIPTION
## Summary
- Header navigation collided with the version chip at viewports around 1200px and left no room for future nav items. Below `xl`, the inline nav is now collapsed into a hamburger dropdown next to the version chip; at `xl+` the centered nav returns.
- The dropdown trigger no longer keeps a lingering focus ring after pointer dismissal (`onCloseAutoFocus` preventDefault).
- The `terminal` button size variant is scaled a notch smaller below `sm` (`gap-2 px-4 py-2 text-xs`) so paired CTAs stop overflowing on narrow phones. Affects every `terminal` CTA app-wide.
- Groups page heading + action buttons switched from a hard `flex-col → sm:flex-row` breakpoint to `flex-wrap`, so they sit side-by-side whenever they fit and wrap automatically when they don't.
- Tooling: ignore `.claude/worktrees/` and track `.worktreeinclude` for worktree-scoped file inclusion.

## Test plan
- [ ] Header at viewports ~1100px, ~1200px, ~1280px, ~1440px — confirm hamburger appears below xl and inline nav at xl+; no collision with version chip.
- [ ] Open hamburger, dismiss by clicking outside — confirm no focus ring lingers on the trigger.
- [ ] Open hamburger, dismiss with Escape — confirm focus is reasonable for keyboard users.
- [ ] Groups page at viewports ~360px, ~430px, ~520px, ~640px — confirm buttons fit beside heading when there is room and wrap below it when there isn't.
- [ ] Spot check other `terminal` CTAs (welcome, dashboard, register, group/game pages) at small widths.