### PR TITLE
feat(frontend): add missing page meta across all routes

### DIFF
--- a/frontend/app/routes/dashboard.tsx
+++ b/frontend/app/routes/dashboard.tsx
@@ -21,6 +21,13 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
     return { queryRef };
 }
 
+export function meta() {
+    return [
+        { title: "Dashboard — Troji" },
+        { name: "description", content: "Your home base. Pick a circle and start handing out trophies." },
+    ];
+}
+
 export function HydrateFallback() {
     return (
         <div className="flex h-full w-full items-center justify-center">

--- a/frontend/app/routes/groups.$id.games.$gameId.tsx
+++ b/frontend/app/routes/groups.$id.games.$gameId.tsx
@@ -73,7 +73,10 @@ export function HydrateFallback() {
 }
 
 export function meta() {
-    return [{ title: "Game — Troji" }];
+    return [
+        { title: "Game — Troji" },
+        { name: "description", content: "Trophy history and stats for this game." },
+    ];
 }
 
 function StatReadout({

--- a/frontend/app/routes/groups.$id.tsx
+++ b/frontend/app/routes/groups.$id.tsx
@@ -89,7 +89,10 @@ export function HydrateFallback() {
 }
 
 export function meta() {
-    return [{ title: "Group — Troji" }];
+    return [
+        { title: "Group — Troji" },
+        { name: "description", content: "Games, members, and trophies for this circle." },
+    ];
 }
 
 function TabCount({ value }: { value: number }) {

--- a/frontend/app/routes/groups.tsx
+++ b/frontend/app/routes/groups.tsx
@@ -46,7 +46,10 @@ export function HydrateFallback() {
 }
 
 export function meta() {
-    return [{ title: "Groups — Troji" }];
+    return [
+        { title: "Groups — Troji" },
+        { name: "description", content: "All your circles. Create one, join one, start competing." },
+    ];
 }
 
 export default function Groups({ loaderData }: Route.ComponentProps) {

--- a/frontend/app/routes/register.tsx
+++ b/frontend/app/routes/register.tsx
@@ -27,6 +27,13 @@ const RegisterUserMutation = graphql`
     }
 `;
 
+export function meta() {
+    return [
+        { title: "Set Up Profile — Troji" },
+        { name: "description", content: "Pick your handle before you enter the arena." },
+    ];
+}
+
 export default function RegisterPage() {
     const { user } = useUser();
     const navigate = useNavigate();

--- a/frontend/app/routes/sign-in.tsx
+++ b/frontend/app/routes/sign-in.tsx
@@ -2,6 +2,13 @@ import { SignIn } from "@clerk/react-router";
 import { AuthShell } from "@/components/AuthShell";
 import { clerkAppearance } from "@/lib/clerk-appearance";
 
+export function meta() {
+    return [
+        { title: "Sign In — Troji" },
+        { name: "description", content: "Sign in to troji and get back in the game." },
+    ];
+}
+
 export default function SignInPage() {
     return (
         <AuthShell prompt="sign in" headline="Welcome back, champion.">

--- a/frontend/app/routes/sign-up.tsx
+++ b/frontend/app/routes/sign-up.tsx
@@ -2,6 +2,13 @@ import { SignUp } from "@clerk/react-router";
 import { AuthShell } from "@/components/AuthShell";
 import { clerkAppearance } from "@/lib/clerk-appearance";
 
+export function meta() {
+    return [
+        { title: "Sign Up — Troji" },
+        { name: "description", content: "Create an account and stake your name in the ledger." },
+    ];
+}
+
 export default function SignUpPage() {
     return (
         <AuthShell prompt="create account" headline="Stake your name in the ledger.">


### PR DESCRIPTION
## Summary
- Added `meta()` exports to `sign-in`, `sign-up`, `register`, and `dashboard` — these had no meta at all
- Added `description` entries to `groups`, `groups.$id`, and `groups.$id.games.$gameId` — these had a title but no description
- Detail pages (`group`, `game`) keep generic titles since they use `clientLoader`, which isn't available to `meta` at render time

## Test plan
- [x] Check browser tab titles on each route
- [x] Inspect `<head>` for `<meta name="description">` on each page