### PR TITLE
fix(frontend): replace scroll-container layout with sticky header

### DIFF
--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -22,7 +22,7 @@ export function Header() {
     const [feedbackOpen, setFeedbackOpen] = useState(false);
 
     return (
-        <header className="z-40 w-full border-b border-border bg-background">
+        <header className="sticky top-0 z-40 w-full border-b border-border bg-background">
             <div className="container relative mx-auto flex h-12 items-center justify-between gap-3 px-4 sm:h-14">
                 <div className="flex items-center gap-2">
                     <VersionChip homeHref="/dashboard" />

--- a/frontend/app/routes/_protected.tsx
+++ b/frontend/app/routes/_protected.tsx
@@ -15,7 +15,7 @@ export async function loader(args: Route.LoaderArgs) {
 
 function FullPageSpinner() {
     return (
-        <div className="flex h-full w-full items-center justify-center">
+        <div className="flex min-h-[50svh] w-full items-center justify-center">
             <div className="flex flex-col items-center gap-3 font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
                 <div className="size-6 animate-spin rounded-full border-2 border-medal-gold/40 border-t-medal-gold" />
                 <span>loading</span>
@@ -27,7 +27,7 @@ function FullPageSpinner() {
 function RouteError({ error }: { error: unknown }) {
     const message = error instanceof Error ? error.message : "An unexpected error occurred.";
     return (
-        <main className="flex h-full w-full flex-col items-center justify-center gap-3 p-8">
+        <main className="flex min-h-[50svh] w-full flex-col items-center justify-center gap-3 p-8">
             <p className="font-mono text-[11px] uppercase tracking-[0.28em] text-destructive">
                 <span aria-hidden className="mr-2">!</span>
                 error
@@ -42,15 +42,13 @@ function RouteError({ error }: { error: unknown }) {
 
 export default function ProtectedLayout() {
     return (
-        <div className="flex h-screen flex-col overflow-hidden">
+        <>
             <Header />
-            <div className="flex-1 overflow-y-auto">
-                <Suspense fallback={<FullPageSpinner />}>
-                    <ErrorBoundary FallbackComponent={RouteError}>
-                        <Outlet />
-                    </ErrorBoundary>
-                </Suspense>
-            </div>
-        </div>
+            <Suspense fallback={<FullPageSpinner />}>
+                <ErrorBoundary FallbackComponent={RouteError}>
+                    <Outlet />
+                </ErrorBoundary>
+            </Suspense>
+        </>
     );
 }


### PR DESCRIPTION
## Summary

- Removes the `h-screen flex-col overflow-hidden` wrapper and inner `flex-1 overflow-y-auto` scroll container from the protected layout — this pattern caused a second native scrollbar (competing with `body`'s `min-h-screen`) and inconsistent header behavior on mobile (`100vh` doesn't account for dynamic browser chrome)
- Makes the `<header>` `sticky top-0` so it anchors to the viewport via native sticky positioning, which works reliably across all viewports
- Updates `FullPageSpinner` and `RouteError` from `h-full` → `min-h-[50svh]` since they no longer have a fixed-height parent

## Test plan

- [ ] Navigate to `/dashboard`, `/groups`, a group detail page — header stays fixed while content scrolls
- [ ] Toggle mobile viewport in DevTools (e.g. iPhone 12) — single scrollbar, header doesn't scroll with content, no layout jump when address bar hides/shows
- [ ] Confirm hamburger nav dropdown still appears above page content (`z-40` preserved)