### PR TITLE
fix: prevent self-handouts in open groups

### DIFF
--- a/backend/api/API/Errors/SelfHandoutException.cs
+++ b/backend/api/API/Errors/SelfHandoutException.cs
@@ -1,0 +1,8 @@
+namespace api.API.Errors;
+
+public sealed class SelfHandoutException : Exception
+{
+    public SelfHandoutException() : base("You cannot award a trophy to yourself.")
+    {
+    }
+}

--- a/backend/api/API/Games/TrophyMutations.cs
+++ b/backend/api/API/Games/TrophyMutations.cs
@@ -15,6 +15,7 @@ public static class TrophyMutations
     [Error<NoUserException>]
     [Error<NoGameException>]
     [Error<NoMemberException>]
+    [Error<SelfHandoutException>]
     public static async Task<Trophy> CreateTrophyRequest(
         [TokenUser] TokenUser? tokenUser,
         [ID] string userId,
@@ -48,6 +49,11 @@ public static class TrophyMutations
         {
             string serializedGroupId2 = serializer.Format(nameof(Group), game.ParentGroupId);
             throw new NoMemberException(tokenUser.Id, serializedGroupId2);
+        }
+
+        if (tokenUser.Id == userId)
+        {
+            throw new SelfHandoutException();
         }
 
         var trophy = new Trophy()

--- a/frontend/app/components/AwardTrophyButton.tsx
+++ b/frontend/app/components/AwardTrophyButton.tsx
@@ -24,8 +24,10 @@ export function AwardTrophyButton({
 }: AwardTrophyButtonProps) {
     const [open, setOpen] = useState(false);
 
+    const eligibleMembers = groupMembers.filter((m) => m.id !== currentUserId);
+
     const disabled =
-        groupMembers.length < 2
+        eligibleMembers.length === 0
             ? { isDisabled: true, reason: "You need at least one other member to award a trophy." }
             : !preselectedGameId && availableGames.length === 0
               ? { isDisabled: true, reason: "Create a game first before awarding trophies." }
@@ -47,7 +49,7 @@ export function AwardTrophyButton({
                 availableGames={availableGames}
                 open={open}
                 onOpenChange={setOpen}
-                groupMembers={groupMembers}
+                groupMembers={eligibleMembers}
                 currentUserId={currentUserId}
             />
         </>


### PR DESCRIPTION
## Summary
- Adds `SelfHandoutException` thrown by `CreateTrophyRequest` when the requester and receiver IDs match — enforces the rule at the API level regardless of how the request is made
- Filters the current user out of the recipient list in `AwardTrophyButton` so the option is never presented in the UI

## Test plan
- [ ] Log in and open the award trophy form — your own name should not appear in the recipient dropdown
- [ ] Confirm another member can still be selected and the trophy is awarded normally
- [ ] Send a raw `createTrophyRequest` mutation with `userId` set to your own ID — response should include `SelfHandoutError` in `errors`