### PR TITLE
style(typography): remove italic from all screens except welcome

### DIFF
--- a/frontend/app/components/AuthShell.tsx
+++ b/frontend/app/components/AuthShell.tsx
@@ -23,7 +23,7 @@ export function AuthShell({ prompt, headline, children }: AuthShellProps) {
             <section className="mx-auto flex w-full max-w-md flex-1 flex-col items-stretch px-6 py-10 sm:py-16">
                 <Breadcrumb segments={[{ label: prompt }]} />
                 {headline ? (
-                    <p className="mt-6 font-heading text-2xl italic leading-snug tracking-[0.025em] text-foreground/95 sm:text-3xl">
+                    <p className="mt-6 font-heading text-2xl leading-snug tracking-[0.025em] text-foreground/95 sm:text-3xl">
                         {headline}
                     </p>
                 ) : null}

--- a/frontend/app/components/GroupActivityFeed.tsx
+++ b/frontend/app/components/GroupActivityFeed.tsx
@@ -79,7 +79,7 @@ export function GroupActivityFeed({ group, currentUserId }: GroupActivityFeedPro
                         <span aria-hidden className="mr-2">▸</span>
                         ledger quiet
                     </p>
-                    <p className="font-heading text-2xl italic tracking-[0.015em] text-foreground sm:text-3xl">
+                    <p className="font-heading text-2xl tracking-[0.015em] text-foreground sm:text-3xl">
                         Nothing&apos;s happened yet.
                     </p>
                 </div>

--- a/frontend/app/components/GroupAside.tsx
+++ b/frontend/app/components/GroupAside.tsx
@@ -46,7 +46,7 @@ export function GroupAside({
             </div>
             {games.length === 0 ? (
                 <div className="surface-card flex flex-col items-start gap-2 p-5">
-                    <p className="font-heading text-base italic tracking-[0.015em]">
+                    <p className="font-heading text-base tracking-[0.015em]">
                         No games yet.
                     </p>
                     <p className="text-xs text-muted-foreground">

--- a/frontend/app/components/GroupHero.tsx
+++ b/frontend/app/components/GroupHero.tsx
@@ -58,11 +58,11 @@ export function GroupHero({
                         <span aria-hidden className="mr-2">▸</span>
                         circle
                     </p>
-                    <h1 className="font-heading text-4xl italic font-medium leading-tight tracking-[0.015em] text-foreground sm:text-5xl">
+                    <h1 className="font-heading text-4xl font-medium leading-tight tracking-[0.015em] text-foreground sm:text-5xl">
                         {data.name}
                     </h1>
                     {data.description ? (
-                        <p className="max-w-2xl font-heading text-lg italic leading-relaxed tracking-[0.015em] text-foreground/85">
+                        <p className="max-w-2xl font-heading text-lg leading-relaxed tracking-[0.015em] text-foreground/85">
                             “{data.description}”
                         </p>
                     ) : null}

--- a/frontend/app/components/GroupTopPerformer.tsx
+++ b/frontend/app/components/GroupTopPerformer.tsx
@@ -55,7 +55,7 @@ export function GroupTopPerformer({
                             middleName={user.middleName}
                             lastName={user.lastName}
                             isSelf={user.id === currentUserId}
-                            className="truncate font-heading text-2xl italic font-medium tracking-[0.015em] text-foreground sm:text-3xl"
+                            className="truncate font-heading text-2xl font-medium tracking-[0.015em] text-foreground sm:text-3xl"
                         />
                         <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-muted-foreground">
                             <span className="text-medal-gold">{count}</span>{" "}
@@ -73,7 +73,7 @@ export function GroupTopPerformer({
                         <span aria-hidden className="mr-2">▸</span>
                         no champion yet
                     </p>
-                    <p className="font-heading text-xl italic tracking-[0.015em] text-foreground sm:text-2xl">
+                    <p className="font-heading text-xl tracking-[0.015em] text-foreground sm:text-2xl">
                         Settle a rivalry. Crown one.
                     </p>
                 </div>

--- a/frontend/app/components/PersonName.tsx
+++ b/frontend/app/components/PersonName.tsx
@@ -34,7 +34,7 @@ export function PersonName({
         <span className={cn("inline-flex items-baseline gap-1", className)}>
             <span>{fullName}</span>
             {isSelf && (
-                <span className={cn("italic text-muted-foreground", selfClassName)}>(you)</span>
+                <span className={cn("text-muted-foreground", selfClassName)}>(you)</span>
             )}
         </span>
     );

--- a/frontend/app/routes/_protected.tsx
+++ b/frontend/app/routes/_protected.tsx
@@ -32,7 +32,7 @@ function RouteError({ error }: { error: unknown }) {
                 <span aria-hidden className="mr-2">!</span>
                 error
             </p>
-            <h1 className="font-heading text-3xl italic tracking-[0.015em] text-foreground">
+            <h1 className="font-heading text-3xl tracking-[0.015em] text-foreground">
                 Something broke.
             </h1>
             <p className="max-w-md text-center text-sm text-muted-foreground">{message}</p>

--- a/frontend/app/routes/dashboard.tsx
+++ b/frontend/app/routes/dashboard.tsx
@@ -47,7 +47,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
         <main className="container mx-auto flex flex-col px-4 py-10 sm:py-14">
             <Breadcrumb segments={[{ label: "dashboard" }]} />
 
-            <h1 className="mt-6 font-heading text-4xl italic font-medium leading-tight tracking-[0.015em] text-foreground sm:text-5xl">
+            <h1 className="mt-6 font-heading text-4xl font-medium leading-tight tracking-[0.015em] text-foreground sm:text-5xl">
                 Welcome back,{" "}
                 <PersonName
                     firstName={data.me?.firstName}

--- a/frontend/app/routes/groups.$id.games.$gameId.tsx
+++ b/frontend/app/routes/groups.$id.games.$gameId.tsx
@@ -131,7 +131,7 @@ export default function GroupGameDetail({ loaderData }: Route.ComponentProps) {
                     <span aria-hidden className="mr-2">!</span>
                     not found
                 </p>
-                <h1 className="font-heading text-3xl italic tracking-[0.015em]">
+                <h1 className="font-heading text-3xl tracking-[0.015em]">
                     No such game.
                 </h1>
                 <Button variant="outline" size="terminal" onClick={() => navigate("/groups")}>
@@ -172,7 +172,7 @@ export default function GroupGameDetail({ loaderData }: Route.ComponentProps) {
                                 <span aria-hidden className="mr-2">▸</span>
                                 game
                             </p>
-                            <h1 className="font-heading text-3xl italic font-medium leading-tight tracking-[0.015em] text-foreground sm:text-4xl">
+                            <h1 className="font-heading text-3xl font-medium leading-tight tracking-[0.015em] text-foreground sm:text-4xl">
                                 {game.name}
                             </h1>
                             {game.description ? (
@@ -254,7 +254,7 @@ export default function GroupGameDetail({ loaderData }: Route.ComponentProps) {
                         ))
                     ) : (
                         <div className="surface-card flex flex-col items-start gap-2 p-6 sm:p-8">
-                            <p className="font-heading text-xl italic tracking-[0.015em]">
+                            <p className="font-heading text-xl tracking-[0.015em]">
                                 Nothing on the board.
                             </p>
                             <p className="text-sm text-muted-foreground">

--- a/frontend/app/routes/groups.$id.tsx
+++ b/frontend/app/routes/groups.$id.tsx
@@ -113,7 +113,7 @@ export default function GroupDetail({ loaderData }: Route.ComponentProps) {
                     <span aria-hidden className="mr-2">!</span>
                     not found
                 </p>
-                <h1 className="font-heading text-3xl italic tracking-[0.015em]">
+                <h1 className="font-heading text-3xl tracking-[0.015em]">
                     That circle isn&apos;t here.
                 </h1>
                 <Button variant="outline" size="terminal" onClick={() => navigate("/groups")}>

--- a/frontend/app/routes/groups.tsx
+++ b/frontend/app/routes/groups.tsx
@@ -68,7 +68,7 @@ export default function Groups({ loaderData }: Route.ComponentProps) {
                 <div className="flex flex-col gap-3">
                     <Breadcrumb segments={[{ label: "groups" }]} />
                     <div className="flex flex-wrap items-end justify-between gap-4">
-                        <h1 className="font-heading text-4xl italic font-medium tracking-[0.015em] text-foreground sm:text-5xl">
+                        <h1 className="font-heading text-4xl font-medium tracking-[0.015em] text-foreground sm:text-5xl">
                             Your circles.
                         </h1>
                         <div className="flex items-center gap-2">
@@ -98,7 +98,7 @@ export default function Groups({ loaderData }: Route.ComponentProps) {
                             <span aria-hidden className="mr-2">▸</span>
                             ledger empty
                         </p>
-                        <p className="font-heading text-2xl italic tracking-[0.015em] text-foreground sm:text-3xl">
+                        <p className="font-heading text-2xl tracking-[0.015em] text-foreground sm:text-3xl">
                             No circles yet — go assemble one.
                         </p>
                         <p className="max-w-md text-sm leading-relaxed text-muted-foreground">


### PR DESCRIPTION
## Context
Italic font usage had spread to almost every heading, empty state, and error message across the app. This PR trims it back so italic is reserved exclusively for the landing screen tagline ("To the victor, the data."), where it was intentional.

## What's changed

- Removed `italic` Tailwind class from all non-welcome screens: dashboard, groups list, group detail, game detail, auth shell, error pages, and all empty states
- Removed italic from the `(you)` marker in `PersonName`
- `welcome.tsx` is untouched — italic stays on the landing tagline
