### PR TITLE
feat(medals): scroll-driven lighting, glare, glow, and carved emoji

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -2,6 +2,8 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/frontend/app/components/MedalBadge.config.ts
+++ b/frontend/app/components/MedalBadge.config.ts
@@ -1,0 +1,69 @@
+// ─── Medal visual parameters ──────────────────────────────────────────────────
+// All tuneable numbers live here. The component reads these but never hardcodes
+// visual values itself, so this is the single place to experiment.
+
+// ── Scroll-driven light position ─────────────────────────────────────────────
+
+/** Focal point of the radial gradient when the medal is at/above center of the
+ *  viewport (the "peak" lighting position), as % of the medal's diameter. */
+export const LIGHT_PEAK = { x: 80, y: 80 } as const;
+
+/** Focal point when the medal is at the bottom of the viewport (dimmed). */
+export const LIGHT_DIM = { x: 15, y: 10 } as const;
+
+/** Gradient stop (%) where the specular hotspot fades into the base metal color.
+ *  Lower = harder, tighter hotspot. Higher = softer, more diffuse. */
+export const SPECULAR_STOP = 15;
+
+// ── Glare streak ─────────────────────────────────────────────────────────────
+
+/** Angle (degrees) of the glare streak at peak lighting (medal at center/top).
+ *  Rotates linearly to DIM_ANGLE as the medal moves toward the bottom.
+ *  Using a direct sweep avoids the atan2 discontinuity. */
+export const GLARE_ANGLE_PEAK = 135;
+export const GLARE_ANGLE_DIM = 85;
+
+/** Max opacity of the streak's bright center line (at peak, u=0). Fades to 0 at dim. */
+export const GLARE_PEAK_OPACITY = 0.82;
+
+/** Gradient stop positions (%) controlling streak width.
+ *  outerFade: where the soft halo begins/ends.
+ *  innerFade: where the bright core begins/ends. */
+export const GLARE_STOPS = { outerFade: 30, innerFade: 46 } as const;
+
+// ── Per-tone gradient colors ──────────────────────────────────────────────────
+
+export type MedalTone = "gold" | "silver" | "bronze";
+
+/** Three-stop radial gradient: specular hotspot → base metal → deep shadow. */
+export const MEDAL_GRADIENT: Record<MedalTone, { spec: string; base: string; shadow: string }> = {
+    gold:   { spec: "oklch(0.98 0.08 84)",   base: "oklch(0.80 0.15 84)",  shadow: "oklch(0.28 0.09 71)"  },
+    silver: { spec: "oklch(0.97 0.005 255)", base: "oklch(0.73 0.02 255)", shadow: "oklch(0.28 0.01 255)" },
+    bronze: { spec: "oklch(0.88 0.12 48)",   base: "oklch(0.58 0.13 48)",  shadow: "oklch(0.22 0.07 38)"  },
+};
+
+// ── Per-tone glow (box-shadow) ────────────────────────────────────────────────
+
+/** Outer glow behind each medal. baseOpacity is scaled by a per-instance random
+ *  factor (0.6–1.4×) so medals in the same tone aren't uniformly identical.
+ *  Gold is most intense (proportional to tier worth). */
+export const MEDAL_GLOW: Record<MedalTone, {
+    blur: number;
+    spread: number;
+    baseOpacity: number;
+    l: number; c: number; h: number; // oklch components of the glow color
+}> = {
+    gold:   { blur: 22, spread: 5, baseOpacity: 0.55, l: 0.78, c: 0.14, h: 84  },
+    silver: { blur: 13, spread: 3, baseOpacity: 0.32, l: 0.73, c: 0.02, h: 255 },
+    bronze: { blur:  8, spread: 2, baseOpacity: 0.20, l: 0.58, c: 0.13, h: 48  },
+};
+
+// ── Size variants ─────────────────────────────────────────────────────────────
+
+export const MEDAL_SIZE = {
+    sm: { frame: "size-9 text-base",  rim: "inset-[1.5px]", stamp: "inset-[14%]" },
+    md: { frame: "size-12 text-xl",   rim: "inset-[2px]",   stamp: "inset-[14%]" },
+    lg: { frame: "size-20 text-4xl",  rim: "inset-[2px]",   stamp: "inset-[12%]" },
+} as const;
+
+export type MedalSize = keyof typeof MEDAL_SIZE;

--- a/frontend/app/components/MedalBadge.css
+++ b/frontend/app/components/MedalBadge.css
@@ -14,29 +14,33 @@
 }
 
 /* ── Frame gradients ──────────────────────────────────────────────────────── */
-/* The gradient focal point is driven by --medal-shine-x/y, updated on scroll. */
+/* Three-stop radial gradient driven entirely by CSS custom properties.
+   --medal-shine-x/y are updated on scroll; colors match MEDAL_GRADIENT in config. */
 
 .medal-frame-gold {
     background: radial-gradient(
         circle at var(--medal-shine-x) var(--medal-shine-y),
-        var(--medal-gold) 0%,
-        var(--medal-gold-shadow) 100%
+        oklch(0.98 0.08 84) 0%,
+        oklch(0.80 0.15 84) 15%,
+        oklch(0.28 0.09 71) 100%
     );
 }
 
 .medal-frame-silver {
     background: radial-gradient(
         circle at var(--medal-shine-x) var(--medal-shine-y),
-        var(--medal-silver) 0%,
-        var(--medal-silver-shadow) 100%
+        oklch(0.97 0.005 255) 0%,
+        oklch(0.73 0.02 255) 15%,
+        oklch(0.28 0.01 255) 100%
     );
 }
 
 .medal-frame-bronze {
     background: radial-gradient(
         circle at var(--medal-shine-x) var(--medal-shine-y),
-        var(--medal-bronze) 0%,
-        var(--medal-bronze-shadow) 100%
+        oklch(0.88 0.12 48) 0%,
+        oklch(0.58 0.13 48) 15%,
+        oklch(0.22 0.07 38) 100%
     );
 }
 

--- a/frontend/app/components/MedalBadge.css
+++ b/frontend/app/components/MedalBadge.css
@@ -1,0 +1,95 @@
+/* Animatable custom properties for the scroll-driven light position.
+   Declared here so they travel with the component. The values are set
+   via inline style on each .medal-badge element by MedalBadge.tsx. */
+@property --medal-shine-x {
+    syntax: "<percentage>";
+    inherits: true;
+    initial-value: 30%;
+}
+
+@property --medal-shine-y {
+    syntax: "<percentage>";
+    inherits: true;
+    initial-value: 25%;
+}
+
+/* ── Frame gradients ──────────────────────────────────────────────────────── */
+/* The gradient focal point is driven by --medal-shine-x/y, updated on scroll. */
+
+.medal-frame-gold {
+    background: radial-gradient(
+        circle at var(--medal-shine-x) var(--medal-shine-y),
+        var(--medal-gold) 0%,
+        var(--medal-gold-shadow) 100%
+    );
+}
+
+.medal-frame-silver {
+    background: radial-gradient(
+        circle at var(--medal-shine-x) var(--medal-shine-y),
+        var(--medal-silver) 0%,
+        var(--medal-silver-shadow) 100%
+    );
+}
+
+.medal-frame-bronze {
+    background: radial-gradient(
+        circle at var(--medal-shine-x) var(--medal-shine-y),
+        var(--medal-bronze) 0%,
+        var(--medal-bronze-shadow) 100%
+    );
+}
+
+/* ── Stamp disc ───────────────────────────────────────────────────────────── */
+
+.medal-stamp-raised {
+    background: radial-gradient(
+        circle at var(--medal-shine-x, 30%) var(--medal-shine-y, 25%),
+        rgba(255, 255, 255, 0.62) 0%,
+        rgba(255, 255, 255, 0.12) 60%,
+        transparent 78%
+    );
+    box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.16);
+}
+
+.medal-stamp-carved {
+    background: radial-gradient(
+        circle at var(--medal-shine-x, 30%) var(--medal-shine-y, 25%),
+        rgba(0, 0, 0, 0.28) 0%,
+        rgba(0, 0, 0, 0.08) 55%,
+        transparent 78%
+    );
+    box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.32), inset 0 1px 2px rgba(0, 0, 0, 0.22);
+}
+
+/* ── Carved emoji filters ─────────────────────────────────────────────────── */
+/* Desaturates the OS-rendered emoji and tints it toward the medal's metal hue,
+   so it reads as a pressed impression rather than a floating sticker. */
+
+.medal-emoji-carved-gold {
+    filter:
+        sepia(1)
+        hue-rotate(5deg)
+        saturate(1.1)
+        brightness(0.52)
+        drop-shadow(-1px -1px 1.5px rgba(0, 0, 0, 0.6))
+        drop-shadow(0px 1px 1px rgba(255, 200, 50, 0.2));
+}
+
+.medal-emoji-carved-silver {
+    filter:
+        saturate(0.08)
+        brightness(0.68)
+        drop-shadow(-1px -1px 1.5px rgba(0, 0, 0, 0.6))
+        drop-shadow(0px 1px 1px rgba(200, 210, 230, 0.2));
+}
+
+.medal-emoji-carved-bronze {
+    filter:
+        sepia(1)
+        hue-rotate(340deg)
+        saturate(1.2)
+        brightness(0.48)
+        drop-shadow(-1px -1px 1.5px rgba(0, 0, 0, 0.6))
+        drop-shadow(0px 1px 1px rgba(180, 100, 30, 0.2));
+}

--- a/frontend/app/components/MedalBadge.tsx
+++ b/frontend/app/components/MedalBadge.tsx
@@ -1,30 +1,65 @@
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import "./MedalBadge.css";
+import {
+    GLARE_ANGLE_DIM,
+    GLARE_ANGLE_PEAK,
+    GLARE_PEAK_OPACITY,
+    GLARE_STOPS,
+    LIGHT_DIM,
+    LIGHT_PEAK,
+    MEDAL_GLOW,
+    MEDAL_GRADIENT,
+    MEDAL_SIZE,
+    SPECULAR_STOP,
+    type MedalSize,
+    type MedalTone,
+} from "./MedalBadge.config";
 
-const medalToneClassName = {
-    gold: "bg-[radial-gradient(circle_at_30%_25%,var(--color-medal-gold)_0%,var(--color-medal-gold-shadow)_100%)]",
-    silver: "bg-[radial-gradient(circle_at_30%_25%,var(--color-medal-silver)_0%,var(--color-medal-silver-shadow)_100%)]",
-    bronze: "bg-[radial-gradient(circle_at_30%_25%,var(--color-medal-bronze)_0%,var(--color-medal-bronze-shadow)_100%)]",
-} as const;
+const toneFrameClass: Record<MedalTone, string> = {
+    gold: "medal-frame-gold",
+    silver: "medal-frame-silver",
+    bronze: "medal-frame-bronze",
+};
 
-const medalSizeClassName = {
-    sm: {
-        frame: "size-9 text-base",
-        rim: "inset-[2.5px]",
-        stamp: "inset-[18%]",
-    },
-    md: {
-        frame: "size-12 text-xl",
-        rim: "inset-[3px]",
-        stamp: "inset-[19%]",
-    },
-} as const;
+const toneCarvedEmojiClass: Record<MedalTone, string> = {
+    gold: "medal-emoji-carved-gold",
+    silver: "medal-emoji-carved-silver",
+    bronze: "medal-emoji-carved-bronze",
+};
+
+// ── Scroll helpers ────────────────────────────────────────────────────────────
+
+/** u=0 at/above viewport center (peak lighting), u=1 at viewport bottom (dim). */
+function scrollProgress(centerY: number): number {
+    return Math.max(0, (centerY / window.innerHeight - 0.5) * 2);
+}
+
+/** Focal point of the gradient for a given scroll progress. */
+function lightPosition(u: number) {
+    return {
+        x: LIGHT_PEAK.x - u * (LIGHT_PEAK.x - LIGHT_DIM.x),
+        y: LIGHT_PEAK.y - u * (LIGHT_PEAK.y - LIGHT_DIM.y),
+    };
+}
+
+/** Glare streak angle and opacity for a given scroll progress.
+ *  Linear sweep avoids the atan2 quadrant-crossing discontinuity. */
+function glareParams(u: number) {
+    return {
+        angle: GLARE_ANGLE_PEAK - u * (GLARE_ANGLE_PEAK - GLARE_ANGLE_DIM),
+        opacity: 1 - u,
+    };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 interface MedalBadgeProps {
     emoji: string;
-    size?: keyof typeof medalSizeClassName;
-    tone?: keyof typeof medalToneClassName;
+    size?: MedalSize;
+    tone?: MedalTone;
     awarded?: boolean;
-    depth?: "flat" | "raised";
+    depth?: "flat" | "raised" | "carved";
     className?: string;
     title?: string;
 }
@@ -34,22 +69,70 @@ export function MedalBadge({
     size = "md",
     tone = "gold",
     awarded = true,
-    depth = "raised",
+    depth = "carved",
     className,
     title,
 }: MedalBadgeProps) {
-    const sizeClassName = medalSizeClassName[size];
+    const { frame, rim, stamp } = MEDAL_SIZE[size];
+    const frameRef = useRef<HTMLSpanElement>(null);
+    const glareRef = useRef<HTMLSpanElement>(null);
+
+    // Stable random glow multiplier per instance (0.6–1.4×)
+    const glowFactor = useRef(0.6 + Math.random() * 0.8).current;
+    const { blur, spread, baseOpacity, l, c, h } = MEDAL_GLOW[tone];
+    const glowAlpha = Math.min(1, baseOpacity * glowFactor).toFixed(2);
+    const glowShadow = `0 0 ${Math.round(blur * glowFactor)}px ${Math.round(spread * glowFactor)}px oklch(${l} ${c} ${h} / ${glowAlpha})`;
+
+    const baseShadow =
+        depth === "raised"  ? "inset 0 1px 1px rgba(255,255,255,0.45), 0 12px 22px -16px rgba(0,0,0,0.9)"
+        : depth === "carved" ? "inset 0 1px 1px rgba(255,255,255,0.25), 0 12px 22px -16px rgba(0,0,0,0.9)"
+        :                      "inset 0 1px 1px rgba(255,255,255,0.2)";
+
+    useEffect(() => {
+        const el = frameRef.current;
+        const glare = glareRef.current;
+        if (!el || !glare) return;
+
+        const { spec, base, shadow } = MEDAL_GRADIENT[tone];
+        const { outerFade, innerFade } = GLARE_STOPS;
+
+        function update() {
+            const rect = el!.getBoundingClientRect();
+            const u = scrollProgress(rect.top + rect.height / 2);
+            const { x, y } = lightPosition(u);
+            const { angle, opacity } = glareParams(u);
+
+            el!.style.backgroundImage = `radial-gradient(circle at ${x.toFixed(1)}% ${y.toFixed(1)}%, ${spec} 0%, ${base} ${SPECULAR_STOP}%, ${shadow} 100%)`;
+            el!.style.setProperty("--medal-shine-x", `${x.toFixed(1)}%`);
+            el!.style.setProperty("--medal-shine-y", `${y.toFixed(1)}%`);
+
+            const a1 = (opacity * GLARE_PEAK_OPACITY * 0.65).toFixed(2);
+            const a2 = (opacity * GLARE_PEAK_OPACITY).toFixed(2);
+            glare!.style.backgroundImage = `linear-gradient(
+                ${angle.toFixed(1)}deg,
+                transparent ${outerFade}%,
+                rgba(255,255,255,${a1}) ${innerFade}%,
+                rgba(255,255,255,${a2}) 50%,
+                rgba(255,255,255,${a1}) ${100 - innerFade}%,
+                transparent ${100 - outerFade}%
+            )`;
+        }
+
+        window.addEventListener("scroll", update, { passive: true });
+        update();
+        return () => window.removeEventListener("scroll", update);
+    }, [tone]);
 
     return (
         <span
+            ref={frameRef}
             title={title}
+            style={{ boxShadow: `${baseShadow}, ${glowShadow}` }}
             className={cn(
+                "medal-badge",
                 "relative inline-flex shrink-0 items-center justify-center rounded-full border border-white/15 text-center",
-                medalToneClassName[tone],
-                sizeClassName.frame,
-                depth === "raised"
-                    ? "shadow-[inset_0_1px_1px_rgba(255,255,255,0.45),0_12px_22px_-16px_rgba(0,0,0,0.9)]"
-                    : "shadow-[inset_0_1px_1px_rgba(255,255,255,0.2)]",
+                toneFrameClass[tone],
+                frame,
                 awarded ? "" : "opacity-45 grayscale saturate-50",
                 className
             )}
@@ -58,17 +141,33 @@ export function MedalBadge({
                 aria-hidden
                 className={cn(
                     "absolute rounded-full border border-white/30 bg-[radial-gradient(circle_at_30%_25%,rgba(255,255,255,0.55),transparent_60%)]",
-                    sizeClassName.rim
+                    rim
                 )}
             />
             <span
                 aria-hidden
                 className={cn(
-                    "absolute rounded-full border border-black/10 bg-[radial-gradient(circle_at_30%_25%,rgba(255,255,255,0.62),rgba(255,255,255,0.12)_60%,transparent_78%)] shadow-[inset_0_-4px_8px_rgba(0,0,0,0.16)]",
-                    sizeClassName.stamp
+                    "absolute rounded-full",
+                    depth === "carved"
+                        ? "border border-black/20 medal-stamp-carved"
+                        : "border border-black/10 medal-stamp-raised",
+                    stamp
                 )}
             />
-            <span className="relative z-10 drop-shadow-[0_1px_1px_rgba(255,255,255,0.35)]">
+            <span
+                ref={glareRef}
+                aria-hidden
+                className="absolute inset-0 rounded-full"
+                style={{ mixBlendMode: "screen" }}
+            />
+            <span
+                className={cn(
+                    "relative z-10",
+                    depth === "carved"
+                        ? toneCarvedEmojiClass[tone]
+                        : "drop-shadow-[0_1px_1px_rgba(255,255,255,0.35)]"
+                )}
+            >
                 {emoji}
             </span>
         </span>

--- a/frontend/app/components/MedalBadge.tsx
+++ b/frontend/app/components/MedalBadge.tsx
@@ -9,9 +9,7 @@ import {
     LIGHT_DIM,
     LIGHT_PEAK,
     MEDAL_GLOW,
-    MEDAL_GRADIENT,
     MEDAL_SIZE,
-    SPECULAR_STOP,
     type MedalSize,
     type MedalTone,
 } from "./MedalBadge.config";
@@ -32,7 +30,7 @@ const toneCarvedEmojiClass: Record<MedalTone, string> = {
 
 /** u=0 at/above viewport center (peak lighting), u=1 at viewport bottom (dim). */
 function scrollProgress(centerY: number): number {
-    return Math.max(0, (centerY / window.innerHeight - 0.5) * 2);
+    return Math.min(1, Math.max(0, (centerY / window.innerHeight - 0.5) * 2));
 }
 
 /** Focal point of the gradient for a given scroll progress. */
@@ -76,12 +74,8 @@ export function MedalBadge({
     const { frame, rim, stamp } = MEDAL_SIZE[size];
     const frameRef = useRef<HTMLSpanElement>(null);
     const glareRef = useRef<HTMLSpanElement>(null);
-
-    // Stable random glow multiplier per instance (0.6–1.4×)
-    const glowFactor = useRef(0.6 + Math.random() * 0.8).current;
-    const { blur, spread, baseOpacity, l, c, h } = MEDAL_GLOW[tone];
-    const glowAlpha = Math.min(1, baseOpacity * glowFactor).toFixed(2);
-    const glowShadow = `0 0 ${Math.round(blur * glowFactor)}px ${Math.round(spread * glowFactor)}px oklch(${l} ${c} ${h} / ${glowAlpha})`;
+    // Initialized lazily in useEffect so it's client-only — avoids SSR/client mismatch.
+    const glowFactorRef = useRef<number | null>(null);
 
     const baseShadow =
         depth === "raised"  ? "inset 0 1px 1px rgba(255,255,255,0.45), 0 12px 22px -16px rgba(0,0,0,0.9)"
@@ -93,8 +87,18 @@ export function MedalBadge({
         const glare = glareRef.current;
         if (!el || !glare) return;
 
-        const { spec, base, shadow } = MEDAL_GRADIENT[tone];
+        // Stable random glow per instance, computed once after mount (client-only).
+        if (glowFactorRef.current === null) {
+            glowFactorRef.current = 0.6 + Math.random() * 0.8;
+        }
+        const glowFactor = glowFactorRef.current;
+        const { blur, spread, baseOpacity, l, c, h } = MEDAL_GLOW[tone];
+        const glowAlpha = Math.min(1, baseOpacity * glowFactor).toFixed(2);
+        const glowShadow = `0 0 ${Math.round(blur * glowFactor)}px ${Math.round(spread * glowFactor)}px oklch(${l} ${c} ${h} / ${glowAlpha})`;
+        el.style.boxShadow = `${baseShadow}, ${glowShadow}`;
+
         const { outerFade, innerFade } = GLARE_STOPS;
+        let rafId: number | null = null;
 
         function update() {
             const rect = el!.getBoundingClientRect();
@@ -102,7 +106,6 @@ export function MedalBadge({
             const { x, y } = lightPosition(u);
             const { angle, opacity } = glareParams(u);
 
-            el!.style.backgroundImage = `radial-gradient(circle at ${x.toFixed(1)}% ${y.toFixed(1)}%, ${spec} 0%, ${base} ${SPECULAR_STOP}%, ${shadow} 100%)`;
             el!.style.setProperty("--medal-shine-x", `${x.toFixed(1)}%`);
             el!.style.setProperty("--medal-shine-y", `${y.toFixed(1)}%`);
 
@@ -118,16 +121,27 @@ export function MedalBadge({
             )`;
         }
 
-        window.addEventListener("scroll", update, { passive: true });
+        function onScroll() {
+            if (rafId !== null) return;
+            rafId = requestAnimationFrame(() => {
+                update();
+                rafId = null;
+            });
+        }
+
+        window.addEventListener("scroll", onScroll, { passive: true });
         update();
-        return () => window.removeEventListener("scroll", update);
-    }, [tone]);
+        return () => {
+            window.removeEventListener("scroll", onScroll);
+            if (rafId !== null) cancelAnimationFrame(rafId);
+        };
+    }, [tone, baseShadow]);
 
     return (
         <span
             ref={frameRef}
             title={title}
-            style={{ boxShadow: `${baseShadow}, ${glowShadow}` }}
+            style={{ boxShadow: baseShadow }}
             className={cn(
                 "medal-badge",
                 "relative inline-flex shrink-0 items-center justify-center rounded-full border border-white/15 text-center",


### PR DESCRIPTION
## Context
Medals are the core visual element of Troji and previously rendered as flat circles with a static gradient and a floating emoji sticker. This PR makes them feel physically real.

## What's changed

- Added scroll-driven lighting: each medal tracks its viewport Y-position and updates a radial gradient hotspot in real time, simulating a fixed light source that medals pass under as the user scrolls
- Added a rotating glare streak (linear gradient overlay, `mix-blend-mode: screen`) that sweeps smoothly as the light angle changes — angle is a direct linear interpolation to avoid the atan2 quadrant-crossing discontinuity
- Added per-tone randomised outer glow (`box-shadow`) proportional to tier worth: gold most intense, bronze least, with a ±40% random factor per instance so medals of the same tone aren't uniform
- Added `depth="carved"` mode (now the default): the emoji is desaturated and tinted toward the metal hue via per-tone CSS filters, and the stamp disc inverts from convex to concave, so the emoji reads as pressed into the metal rather than sitting on top
- Extracted all tuneable visual parameters to `MedalBadge.config.ts` — light positions, specular stop, glare angles, glow values, gradient colors — so anyone can adjust the look without reading component logic
- Moved all medal-specific CSS out of `app.css` into a co-located `MedalBadge.css`, imported directly from the component for portability
